### PR TITLE
feaf : review CRUD 구현

### DIFF
--- a/src/main/java/jeje/work/aeatbe/controller/ReviewController.java
+++ b/src/main/java/jeje/work/aeatbe/controller/ReviewController.java
@@ -16,16 +16,28 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * 리뷰 컨트롤러
+ */
 @RestController
 @RequestMapping("/api/reviews")
 public class ReviewController {
 
     private final ReviewService reviewService;
-
+    
     public ReviewController(ReviewService reviewService) {
         this.reviewService = reviewService;
     }
 
+
+    /**
+     * 칼럼 조회
+     *
+     * @param searchByUser 마이페이지 여부(true = 마이페이지, false = 단순 상품 리뷰)
+     * @param productId    상품 id
+     * @param token        유저 토큰
+     * @return list 형식의 reviewDTO
+     */
     @GetMapping
     public ResponseEntity<List<ReviewDTO>> getReviews(
         @RequestParam(required = false) boolean searchByUser,
@@ -41,6 +53,13 @@ public class ReviewController {
     }
 
 
+    /**
+     * 새 리뷰 생성
+     *
+     * @param reviewDTO 리뷰 DTO
+     * @param token     유저 토큰
+     * @return 201 created 응답 코드
+     */
     @PostMapping
     public ResponseEntity<?> postReviews(@RequestBody ReviewDTO reviewDTO,
         @RequestHeader(required = true, value = "Authorization") String token) {
@@ -51,6 +70,14 @@ public class ReviewController {
 
     }
 
+    /**
+     * 리뷰 수정
+     *
+     * @param id        리뷰 id
+     * @param reviewDTO 리뷰 DTO
+     * @param token     유저 토큰
+     * @return 200 ok 응답 코드
+     */
     @PatchMapping("/{id}")
     public ResponseEntity<?> updateReviews(@PathVariable Long id,
         @RequestBody ReviewDTO reviewDTO,
@@ -59,6 +86,13 @@ public class ReviewController {
         return ResponseEntity.ok().build();
     }
 
+    /**
+     * 리뷰 삭제
+     *
+     * @param id    리뷰 id
+     * @param token 유저 토큰
+     * @return 204 응답 코드 반환
+     */
     @DeleteMapping("/{id}")
     public ResponseEntity<?> deleteReviews(@PathVariable Long id,
         @RequestHeader(required = true, value = "Authorization") String token) {

--- a/src/main/java/jeje/work/aeatbe/controller/ReviewController.java
+++ b/src/main/java/jeje/work/aeatbe/controller/ReviewController.java
@@ -1,0 +1,66 @@
+package jeje.work.aeatbe.controller;
+
+import java.util.List;
+import jeje.work.aeatbe.dto.ReviewDTO;
+import jeje.work.aeatbe.service.ReviewService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/reviews")
+public class ReviewController {
+
+    private final ReviewService reviewService;
+
+    public ReviewController(ReviewService reviewService) {
+        this.reviewService = reviewService;
+    }
+
+    @GetMapping
+    public ResponseEntity<List<ReviewDTO>> getReviews(
+        @RequestParam(required = false) boolean searchByUser,
+        @RequestParam(required = true) Long productId,
+        @RequestHeader(required = false, value = "Authorization") String token
+    ) {
+        if (searchByUser && (token == null || token.isEmpty()))
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+
+        /* token 부분은 추후 토큰에서 필요한 정보를 뽑아서 대체 할 예정입니다.*/
+        List<ReviewDTO> reviews = reviewService.getReviews(searchByUser, productId, token);
+        return ResponseEntity.ok(reviews);
+    }
+
+
+    @PostMapping
+    public ResponseEntity<?> postReviews(@RequestBody ReviewDTO reviewDTO,
+        @RequestHeader(required = true, value = "Authorization") String token) {
+
+        // 이 부분은 추후 수정 될 예정
+        reviewService.createReview(reviewDTO, token);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+
+    }
+
+    @PatchMapping("/{id}")
+    public ResponseEntity<?> updateReviews(@PathVariable Long id, @RequestBody ReviewDTO reviewDTO) {
+        reviewService.updateReviews(id, reviewDTO);
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<?> deleteReviews(@PathVariable Long id) {
+        reviewService.deleteReviews(id);
+        return ResponseEntity.noContent().build();
+    }
+
+}

--- a/src/main/java/jeje/work/aeatbe/controller/ReviewController.java
+++ b/src/main/java/jeje/work/aeatbe/controller/ReviewController.java
@@ -52,13 +52,16 @@ public class ReviewController {
     }
 
     @PatchMapping("/{id}")
-    public ResponseEntity<?> updateReviews(@PathVariable Long id, @RequestBody ReviewDTO reviewDTO) {
+    public ResponseEntity<?> updateReviews(@PathVariable Long id,
+        @RequestBody ReviewDTO reviewDTO,
+        @RequestHeader(required = true, value = "Authorization") String token) {
         reviewService.updateReviews(id, reviewDTO);
         return ResponseEntity.ok().build();
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<?> deleteReviews(@PathVariable Long id) {
+    public ResponseEntity<?> deleteReviews(@PathVariable Long id,
+        @RequestHeader(required = true, value = "Authorization") String token) {
         reviewService.deleteReviews(id);
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/jeje/work/aeatbe/dto/ReviewDTO.java
+++ b/src/main/java/jeje/work/aeatbe/dto/ReviewDTO.java
@@ -1,0 +1,20 @@
+package jeje.work.aeatbe.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReviewDTO {
+
+    private Long id;
+    private int rate;
+    private String content;
+    private UserDTO user;
+    private Long productId;
+
+}

--- a/src/main/java/jeje/work/aeatbe/dto/UserDTO.java
+++ b/src/main/java/jeje/work/aeatbe/dto/UserDTO.java
@@ -11,5 +11,20 @@ public class UserDTO {
     private String userId;
     private String allergies;
     private String freeFrom;
+    private String userName;
+    private String userImgUrl;
+
+    public UserDTO(Long id, String userName, String userImgUrl) {
+        this.id = id;
+        this.userName = userName;
+        this.userImgUrl = userImgUrl;
+    }
+
+    public UserDTO(Long id, String userId, String allergies, String freeFrom) {
+        this.id = id;
+        this.userId = userId;
+        this.allergies = allergies;
+        this.freeFrom = freeFrom;
+    }
 
 }

--- a/src/main/java/jeje/work/aeatbe/dto/UserDTO.java
+++ b/src/main/java/jeje/work/aeatbe/dto/UserDTO.java
@@ -20,11 +20,4 @@ public class UserDTO {
         this.userImgUrl = userImgUrl;
     }
 
-    public UserDTO(Long id, String userId, String allergies, String freeFrom) {
-        this.id = id;
-        this.userId = userId;
-        this.allergies = allergies;
-        this.freeFrom = freeFrom;
-    }
-
 }

--- a/src/main/java/jeje/work/aeatbe/entity/Review.java
+++ b/src/main/java/jeje/work/aeatbe/entity/Review.java
@@ -1,0 +1,40 @@
+package jeje.work.aeatbe.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Lob;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table(name = "reviews")
+public class Review extends BaseEntity{
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private int rate;
+
+    @Lob
+    private String content;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne
+    @JoinColumn(name = "product_id", nullable = false)
+    private Product product;
+
+}

--- a/src/main/java/jeje/work/aeatbe/entity/User.java
+++ b/src/main/java/jeje/work/aeatbe/entity/User.java
@@ -1,8 +1,6 @@
 package jeje.work.aeatbe.entity;
 
 import jakarta.persistence.*;
-import java.util.HashSet;
-import java.util.Set;
 import lombok.*;
 
 @Entity
@@ -24,7 +22,11 @@ public class User extends BaseEntity{
 
     @Column(name = "free_from", length = 100)
     private String freeFrom;
-    
 
+    @Column(name = "user_name", nullable = false, length = 15)
+    private String userName;
+
+    @Column(name = "user_img_url", length = 255)
+    private String userImgUrl;
 
 }

--- a/src/main/java/jeje/work/aeatbe/exception/GlobalExceptionHandler.java
+++ b/src/main/java/jeje/work/aeatbe/exception/GlobalExceptionHandler.java
@@ -17,4 +17,16 @@ public class GlobalExceptionHandler {
     public ResponseEntity notFoundColumnException(NotFoundColumnException e){
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(e.getMessage());
     }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity illegalArgumentException(IllegalArgumentException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
+    }
+
+    @ExceptionHandler(IllegalStateException.class)
+    public ResponseEntity illegalStateException(IllegalStateException e) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(e.getMessage());
+    }
+
+
 }

--- a/src/main/java/jeje/work/aeatbe/exception/IllegalArgumentException.java
+++ b/src/main/java/jeje/work/aeatbe/exception/IllegalArgumentException.java
@@ -1,0 +1,7 @@
+package jeje.work.aeatbe.exception;
+
+public class IllegalArgumentException extends RuntimeException{
+    public IllegalArgumentException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/jeje/work/aeatbe/exception/IllegalStateException.java
+++ b/src/main/java/jeje/work/aeatbe/exception/IllegalStateException.java
@@ -1,0 +1,7 @@
+package jeje.work.aeatbe.exception;
+
+public class IllegalStateException extends RuntimeException{
+    public IllegalStateException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/jeje/work/aeatbe/repository/ReviewRepository.java
+++ b/src/main/java/jeje/work/aeatbe/repository/ReviewRepository.java
@@ -1,0 +1,13 @@
+package jeje.work.aeatbe.repository;
+
+
+import java.util.List;
+import jeje.work.aeatbe.entity.Review;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ReviewRepository extends JpaRepository<Review, Long> {
+    List<Review> findByUserId(Long userId);
+    List<Review> findByProductId(Long productId);
+}

--- a/src/main/java/jeje/work/aeatbe/service/ReviewService.java
+++ b/src/main/java/jeje/work/aeatbe/service/ReviewService.java
@@ -34,10 +34,12 @@ public class ReviewService {
             Long userId = 1L;
             reviews = reviewRepository.findByUserId(userId);
 
-        } else if (productId != null) {
+        } else{
             reviews = reviewRepository.findByProductId(productId);
-        } else {
-            throw new IllegalArgumentException("product_id는 필수입니다.");
+        }
+
+        if (reviews.isEmpty()) {
+            throw new IllegalArgumentException("해당 product_id로 조회된 리뷰가 없습니다.");
         }
 
         return reviews.stream()
@@ -91,7 +93,6 @@ public class ReviewService {
         );
 
         reviewRepository.save(updateReview);
-
     }
 
     public void deleteReviews(Long id) {

--- a/src/main/java/jeje/work/aeatbe/service/ReviewService.java
+++ b/src/main/java/jeje/work/aeatbe/service/ReviewService.java
@@ -12,6 +12,9 @@ import jeje.work.aeatbe.repository.ReviewRepository;
 import jeje.work.aeatbe.repository.UserRepository;
 import org.springframework.stereotype.Service;
 
+/**
+ * 리뷰 서비스 레이어
+ */
 @Service
 public class ReviewService {
     private final ReviewRepository reviewRepository;
@@ -24,6 +27,14 @@ public class ReviewService {
         this.productRepository = productRepository;
     }
 
+    /**
+     * 리뷰 조회
+     *
+     * @param searchByUser 마이페이지 여부(true = 마이페이지, false = 단순 상품 리뷰)
+     * @param productId    상품 id
+     * @param token        유저 토큰
+     * @return list 형식의 reviewDTO
+     */
     public List<ReviewDTO> getReviews(boolean searchByUser, Long productId, String token) {
         List<Review> reviews = List.of();
         if (searchByUser) {
@@ -57,6 +68,12 @@ public class ReviewService {
             .collect(Collectors.toList());
     }
 
+    /**
+     * 새 리뷰 생성
+     *
+     * @param reviewDTO 리뷰 DTO
+     * @param token     유저 토큰
+     */
     public void createReview(ReviewDTO reviewDTO, String token) {
 
         // 현재는 임시로 이렇게 해 두고 토큰이 생기면 수정하겠습니다
@@ -80,6 +97,12 @@ public class ReviewService {
 
     }
 
+    /**
+     * 리뷰 수정
+     *
+     * @param id        리뷰 id
+     * @param reviewDTO 리뷰 DTO
+     */
     public void updateReviews(Long id, ReviewDTO reviewDTO) {
         Review existingReview = reviewRepository.findById(id)
             .orElseThrow(()-> new IllegalArgumentException("해당 상품의 리뷰가 존재하지 않습니다."));
@@ -95,6 +118,11 @@ public class ReviewService {
         reviewRepository.save(updateReview);
     }
 
+    /**
+     * 리뷰 삭제
+     *
+     * @param id 리뷰 id
+     */
     public void deleteReviews(Long id) {
         Review existingReview = reviewRepository.findById(id)
             .orElseThrow(() -> new IllegalArgumentException("ID: " + id + "에 대한 리뷰를 찾을 수 없습니다."));

--- a/src/main/java/jeje/work/aeatbe/service/ReviewService.java
+++ b/src/main/java/jeje/work/aeatbe/service/ReviewService.java
@@ -1,0 +1,104 @@
+package jeje.work.aeatbe.service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import jeje.work.aeatbe.dto.ReviewDTO;
+import jeje.work.aeatbe.dto.UserDTO;
+import jeje.work.aeatbe.entity.Product;
+import jeje.work.aeatbe.entity.Review;
+import jeje.work.aeatbe.entity.User;
+import jeje.work.aeatbe.repository.ProductRepository;
+import jeje.work.aeatbe.repository.ReviewRepository;
+import jeje.work.aeatbe.repository.UserRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ReviewService {
+    private final ReviewRepository reviewRepository;
+    private final UserRepository userRepository;
+    private final ProductRepository productRepository;
+
+    public ReviewService(ReviewRepository reviewRepository, UserRepository userRepository, ProductRepository productRepository) {
+        this.reviewRepository = reviewRepository;
+        this.userRepository = userRepository;
+        this.productRepository = productRepository;
+    }
+
+    public List<ReviewDTO> getReviews(boolean searchByUser, Long productId, String token) {
+        List<Review> reviews = List.of();
+        if (searchByUser) {
+            if (token == null || token.isEmpty()) {
+                throw new IllegalStateException("로그인이 필요합니다.");
+            }
+            // 여기서 토큰을 디코딩하여 사용자 ID 추출하는 코드 추가 예정 (token)
+            Long userId = 1L;
+            reviews = reviewRepository.findByUserId(userId);
+
+        } else if (productId != null) {
+            reviews = reviewRepository.findByProductId(productId);
+        } else {
+            throw new IllegalArgumentException("product_id는 필수입니다.");
+        }
+
+        return reviews.stream()
+            .map(review -> new ReviewDTO(
+                review.getId(),
+                review.getRate(),
+                review.getContent(),
+                new UserDTO(
+                    review.getUser().getId(),
+                    review.getUser().getUserName(),
+                    review.getUser().getUserImgUrl()
+                ),
+                review.getProduct().getId()
+            ))
+            .collect(Collectors.toList());
+    }
+
+    public void createReview(ReviewDTO reviewDTO, String token) {
+
+        // 현재는 임시로 이렇게 해 두고 토큰이 생기면 수정하겠습니다
+        Long userId = reviewDTO.getUser().getId();
+
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        Product product = productRepository.findById(reviewDTO.getProductId())
+            .orElseThrow(() -> new IllegalArgumentException("상품을 찾을 수 없습니다."));
+
+        Review review = new Review(
+            reviewDTO.getId(),
+            reviewDTO.getRate(),
+            reviewDTO.getContent(),
+            user,
+            product
+        );
+
+        reviewRepository.save(review);
+
+    }
+
+    public void updateReviews(Long id, ReviewDTO reviewDTO) {
+        Review existingReview = reviewRepository.findById(id)
+            .orElseThrow(()-> new IllegalArgumentException("해당 상품의 리뷰가 존재하지 않습니다."));
+
+        Review updateReview = new Review(
+            existingReview.getId(),
+            reviewDTO.getRate(),
+            reviewDTO.getContent(),
+            existingReview.getUser(),
+            existingReview.getProduct()
+        );
+
+        reviewRepository.save(updateReview);
+
+    }
+
+    public void deleteReviews(Long id) {
+        Review existingReview = reviewRepository.findById(id)
+            .orElseThrow(() -> new IllegalArgumentException("ID: " + id + "에 대한 리뷰를 찾을 수 없습니다."));
+
+        reviewRepository.delete(existingReview);
+    }
+
+}

--- a/src/test/java/jeje/work/aeatbe/EntityRepositoryTests.java
+++ b/src/test/java/jeje/work/aeatbe/EntityRepositoryTests.java
@@ -65,7 +65,9 @@ public class EntityRepositoryTests {
             userDTO.getId(),
             userDTO.getUserId(),
             userDTO.getAllergies(),
-            userDTO.getFreeFrom()
+            userDTO.getFreeFrom(),
+            "Test User",
+            "https://testImg.com"
         );
 
         User savedUser = userRepository.save(user);
@@ -103,7 +105,9 @@ public class EntityRepositoryTests {
             userDTO.getId(),
             userDTO.getUserId(),
             userDTO.getAllergies(),
-            userDTO.getFreeFrom()
+            userDTO.getFreeFrom(),
+            "Test User",
+            "https://testImg.com"
         );
         userRepository.save(user);
 


### PR DESCRIPTION
- review crud를 구현하였습니다. 
- 리뷰 내 content는 null이 가능하게 해뒀습니다(별점만 남길 수 있음)
- 한 상품에 대해 여러 개의 리뷰를 남길 수 있도록 review테이블과 product를 다대일로 설정 했습니다.
- api 문서에 따라 user dto와 entity에 userName(유저 닉네임)과 userImgUrl(프로필 이미지) 필드를 추가하였습니다.
- user 필드 추가에 따른 test 코드 객체 생성 부분을 약간 수정하였습니다.
- exception에 IllegalArumentException과 Illegalstateexception을 추가하였습니다.
- 모든 Http method 헤더에 토큰을 사용하도록 하였습니다.


현재 토큰 기능이 구현되지 않아 대체로 임시 코드들을 작성 해 둔 상태입니다. 추후에 그 부분은 토큰이 생긴 후 수정하겠습니다.