### PR TITLE
feat : Review Service 빌더패턴 적용 마이페이지 분리

### DIFF
--- a/src/main/java/jeje/work/aeatbe/controller/AllergyCategoryController.java
+++ b/src/main/java/jeje/work/aeatbe/controller/AllergyCategoryController.java
@@ -1,6 +1,6 @@
 package jeje.work.aeatbe.controller;
 
-import jeje.work.aeatbe.dto.AllergyCategory.AllergyCategoryDTO;
+import jeje.work.aeatbe.dto.allergyCategory.AllergyCategoryDTO;
 import jeje.work.aeatbe.service.AllergyCategoryService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/jeje/work/aeatbe/controller/ReviewController.java
+++ b/src/main/java/jeje/work/aeatbe/controller/ReviewController.java
@@ -1,6 +1,7 @@
 package jeje.work.aeatbe.controller;
 
 import java.util.List;
+import jeje.work.aeatbe.annotation.LoginUser;
 import jeje.work.aeatbe.dto.review.ReviewDTO;
 import jeje.work.aeatbe.service.ReviewService;
 import org.springframework.http.HttpStatus;
@@ -11,7 +12,6 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -24,7 +24,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class ReviewController {
 
     private final ReviewService reviewService;
-    
+
     public ReviewController(ReviewService reviewService) {
         this.reviewService = reviewService;
     }
@@ -33,24 +33,32 @@ public class ReviewController {
     /**
      * 칼럼 조회
      *
-     * @param searchByUser 마이페이지 여부(true = 마이페이지, false = 단순 상품 리뷰)
      * @param productId    상품 id
-     * @param token        유저 토큰
      * @return list 형식의 reviewDTO
      *
-     * @todo 토큰에서 필요한 정보를 추출하는 코드를 구현해야 함
      */
     @GetMapping
     public ResponseEntity<List<ReviewDTO>> getReviews(
-        @RequestParam(required = false) boolean searchByUser,
-        @RequestParam(required = true) Long productId,
-        @RequestHeader(required = false, value = "Authorization") String token
-    ) {
-        if (searchByUser && (token == null || token.isEmpty()))
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        @RequestParam(required = true) Long productId) {
 
-        List<ReviewDTO> reviews = reviewService.getReviews(searchByUser, productId, token);
+        List<ReviewDTO> reviews = reviewService.getReviews(productId);
         return ResponseEntity.ok(reviews);
+    }
+
+
+    /**
+     * 특정 유저에 대한 리뷰를 조회
+     *
+     * @param kakaoId the kakao id
+     * @return 특정 유저에 관한 리뷰 리스트
+     *
+     * @todo: kakaoId -> userId로 수정 필요
+     */
+    @GetMapping("/my")
+    public ResponseEntity<?> getReivewsByUser(@LoginUser String kakaoId) {
+        List<ReviewDTO> review = reviewService.getReviewsByUser(kakaoId);
+
+        return ResponseEntity.ok(review);
     }
 
 
@@ -58,17 +66,15 @@ public class ReviewController {
      * 새 리뷰 생성
      *
      * @param reviewDTO 리뷰 DTO
-     * @param token     유저 토큰
+     * @param kakaoId   the kakao id
      * @return 201 created 응답 코드
      *
-     * @todo 토큰에서 필요한 정보를 추출하는 코드를 구현해야 함
-     * @todo 토큰 인증하는 로직 필요
+     * @todo: kakaoId -> userId로 수정 필요
      */
     @PostMapping
     public ResponseEntity<?> postReviews(@RequestBody ReviewDTO reviewDTO,
-        @RequestHeader(required = true, value = "Authorization") String token) {
-
-        reviewService.createReview(reviewDTO, token);
+        @LoginUser String kakaoId) {
+        reviewService.createReview(reviewDTO, kakaoId);
         return ResponseEntity.status(HttpStatus.CREATED).build();
 
     }
@@ -78,34 +84,33 @@ public class ReviewController {
      *
      * @param id        리뷰 id
      * @param reviewDTO 리뷰 DTO
-     * @param token     유저 토큰
+     * @param kakaoId   the kakao id
      * @return 200 ok 응답 코드
      *
-     * @todo 토큰에서 필요한 정보를 추출하는 코드를 구현해야 함
-     * @todo 토큰 인증하는 로직 필요
+     * @todo: kakaoId -> userId로 수정 필요
      */
     @PatchMapping("/{id}")
     public ResponseEntity<?> updateReviews(@PathVariable Long id,
         @RequestBody ReviewDTO reviewDTO,
-        @RequestHeader(required = true, value = "Authorization") String token) {
-        reviewService.updateReviews(id, reviewDTO);
+        @LoginUser String kakaoId) {
+        reviewService.updateReviews(id, reviewDTO, kakaoId);
         return ResponseEntity.ok().build();
     }
 
     /**
      * 리뷰 삭제
      *
-     * @param id    리뷰 id
-     * @param token 유저 토큰
+     * @param id      리뷰 id
+     * @param kakaoId the kakao id
      * @return 204 응답 코드 반환
      *
-     * @todo 토큰에서 필요한 정보를 추출하는 코드를 구현해야 함
-     * @todo 토큰 인증하는 로직 필요
+     * @todo: kakaoId -> userId로 수정 필요
+     *
      */
     @DeleteMapping("/{id}")
     public ResponseEntity<?> deleteReviews(@PathVariable Long id,
-        @RequestHeader(required = true, value = "Authorization") String token) {
-        reviewService.deleteReviews(id);
+        @LoginUser String kakaoId) {
+        reviewService.deleteReviews(id, kakaoId);
         return ResponseEntity.noContent().build();
     }
 

--- a/src/main/java/jeje/work/aeatbe/controller/UserController.java
+++ b/src/main/java/jeje/work/aeatbe/controller/UserController.java
@@ -4,7 +4,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import jeje.work.aeatbe.domian.KakaoProperties;
 import jeje.work.aeatbe.domian.KakaoTokenResponsed;
-import jeje.work.aeatbe.dto.User.TokenResponseDto;
+import jeje.work.aeatbe.dto.user.TokenResponseDto;
 import jeje.work.aeatbe.service.UserService;
 import jeje.work.aeatbe.utility.JwtUtil;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/jeje/work/aeatbe/dto/allergyCategory/AllergyCategoryDTO.java
+++ b/src/main/java/jeje/work/aeatbe/dto/allergyCategory/AllergyCategoryDTO.java
@@ -1,4 +1,4 @@
-package jeje.work.aeatbe.dto.AllergyCategory;
+package jeje.work.aeatbe.dto.allergyCategory;
 
 import lombok.Builder;
 

--- a/src/main/java/jeje/work/aeatbe/dto/review/ReviewDTO.java
+++ b/src/main/java/jeje/work/aeatbe/dto/review/ReviewDTO.java
@@ -1,6 +1,7 @@
 package jeje.work.aeatbe.dto.review;
 
-import jeje.work.aeatbe.dto.User.UserDTO;
+import java.util.Optional;
+import jeje.work.aeatbe.dto.user.UserDTO;
 import lombok.Builder;
 
 @Builder
@@ -8,6 +9,7 @@ public record ReviewDTO(Long id,
                         int rate,
                         String content,
                         UserDTO user,
-                        Long productId) {
+                        Long productId,
+                        Optional<String> productImgUrl) {
 
 }

--- a/src/main/java/jeje/work/aeatbe/dto/user/TokenResponseDto.java
+++ b/src/main/java/jeje/work/aeatbe/dto/user/TokenResponseDto.java
@@ -1,4 +1,4 @@
-package jeje.work.aeatbe.dto.User;
+package jeje.work.aeatbe.dto.user;
 
 import lombok.Builder;
 

--- a/src/main/java/jeje/work/aeatbe/dto/user/UserAllergyDTO.java
+++ b/src/main/java/jeje/work/aeatbe/dto/user/UserAllergyDTO.java
@@ -1,4 +1,4 @@
-package jeje.work.aeatbe.dto.User;
+package jeje.work.aeatbe.dto.user;
 
 
 import lombok.Builder;

--- a/src/main/java/jeje/work/aeatbe/dto/user/UserDTO.java
+++ b/src/main/java/jeje/work/aeatbe/dto/user/UserDTO.java
@@ -1,4 +1,4 @@
-package jeje.work.aeatbe.dto.User;
+package jeje.work.aeatbe.dto.user;
 import lombok.*;
 
 

--- a/src/main/java/jeje/work/aeatbe/dto/user/UserFreeFromDTO.java
+++ b/src/main/java/jeje/work/aeatbe/dto/user/UserFreeFromDTO.java
@@ -1,4 +1,4 @@
-package jeje.work.aeatbe.dto.User;
+package jeje.work.aeatbe.dto.user;
 
 import lombok.*;
 

--- a/src/main/java/jeje/work/aeatbe/entity/Product.java
+++ b/src/main/java/jeje/work/aeatbe/entity/Product.java
@@ -55,4 +55,7 @@ public class Product extends BaseEntity{
 
     @OneToMany(mappedBy = "product", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ProductFreeFrom> productFreeFroms;
+
+    @OneToMany(mappedBy = "product", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Review> reviews;
 }

--- a/src/main/java/jeje/work/aeatbe/entity/User.java
+++ b/src/main/java/jeje/work/aeatbe/entity/User.java
@@ -30,8 +30,8 @@ public class User extends BaseEntity{
     @Column(name = "user_img_url", length = 255)
     private String userImgUrl;
 
-//    @Column
-//    private String kakaoId;
+    @Column
+    private String kakaoId;
 
     @Column
     private String accessToken;

--- a/src/main/java/jeje/work/aeatbe/mapper/allergyCategory/AllergyCategoryMapper.java
+++ b/src/main/java/jeje/work/aeatbe/mapper/allergyCategory/AllergyCategoryMapper.java
@@ -1,6 +1,6 @@
 package jeje.work.aeatbe.mapper.allergyCategory;
 
-import jeje.work.aeatbe.dto.AllergyCategory.AllergyCategoryDTO;
+import jeje.work.aeatbe.dto.allergyCategory.AllergyCategoryDTO;
 import jeje.work.aeatbe.entity.AllergyCategory;
 import org.springframework.stereotype.Component;
 

--- a/src/main/java/jeje/work/aeatbe/repository/UserRepository.java
+++ b/src/main/java/jeje/work/aeatbe/repository/UserRepository.java
@@ -9,5 +9,6 @@ import org.springframework.stereotype.Repository;
 public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByUserId(String userId);
+    Optional<Long> findByKakaoId(String userId);
 
 }

--- a/src/main/java/jeje/work/aeatbe/service/AllergyCategoryService.java
+++ b/src/main/java/jeje/work/aeatbe/service/AllergyCategoryService.java
@@ -1,6 +1,6 @@
 package jeje.work.aeatbe.service;
 
-import jeje.work.aeatbe.dto.AllergyCategory.AllergyCategoryDTO;
+import jeje.work.aeatbe.dto.allergyCategory.AllergyCategoryDTO;
 import jeje.work.aeatbe.entity.AllergyCategory;
 import jeje.work.aeatbe.exception.AllergyCategoryNotFoundException;
 import jeje.work.aeatbe.mapper.allergyCategory.AllergyCategoryMapper;

--- a/src/main/java/jeje/work/aeatbe/service/ProductAllergyService.java
+++ b/src/main/java/jeje/work/aeatbe/service/ProductAllergyService.java
@@ -1,6 +1,6 @@
 package jeje.work.aeatbe.service;
 
-import jeje.work.aeatbe.dto.AllergyCategory.AllergyCategoryDTO;
+import jeje.work.aeatbe.dto.allergyCategory.AllergyCategoryDTO;
 import jeje.work.aeatbe.dto.product.ProductAllergyDTO;
 import jeje.work.aeatbe.entity.AllergyCategory;
 import jeje.work.aeatbe.entity.Product;

--- a/src/main/java/jeje/work/aeatbe/service/ProductService.java
+++ b/src/main/java/jeje/work/aeatbe/service/ProductService.java
@@ -170,7 +170,6 @@ public class ProductService {
     @Transactional
     public void deleteProduct(Long id) {
         var product = getProductEntity(id);
-        reviewService.deleteReviewsByProductId(id);
         productRepository.delete(product);
     }
 }

--- a/src/main/java/jeje/work/aeatbe/service/ReviewService.java
+++ b/src/main/java/jeje/work/aeatbe/service/ReviewService.java
@@ -1,9 +1,10 @@
 package jeje.work.aeatbe.service;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import jeje.work.aeatbe.dto.review.ReviewDTO;
-import jeje.work.aeatbe.dto.User.UserDTO;
+import jeje.work.aeatbe.dto.user.UserDTO;
 import jeje.work.aeatbe.entity.Product;
 import jeje.work.aeatbe.entity.Review;
 import jeje.work.aeatbe.entity.User;
@@ -30,52 +31,12 @@ public class ReviewService {
     /**
      * 리뷰 조회
      *
-     * @param searchByUser 마이페이지 여부(true = 마이페이지, false = 단순 상품 리뷰)
      * @param productId    상품 id
-     * @param token        유저 토큰
      * @return list 형식의 reviewDTO
      *
      * @todo 토큰에서 파싱된 정보를 기반으로 userId에 들어갈 값을 수정 해야 함
      */
-    public List<ReviewDTO> getReviews(boolean searchByUser, Long productId, String token) {
-        List<Review> reviews = List.of();
-        if (searchByUser) {
-            if (token == null || token.isEmpty()) {
-                throw new IllegalStateException("로그인이 필요합니다.");
-            }
-
-            Long userId = 1L;
-            reviews = reviewRepository.findByUserId(userId);
-
-        } else{
-            reviews = reviewRepository.findByProductId(productId);
-        }
-
-        if (reviews.isEmpty()) {
-            throw new IllegalArgumentException("해당 product_id로 조회된 리뷰가 없습니다.");
-        }
-
-        return reviews.stream()
-            .map(review -> new ReviewDTO(
-                review.getId(),
-                review.getRate(),
-                review.getContent(),
-                new UserDTO(
-                    review.getUser().getId(),
-                    review.getUser().getUserName(),
-                    review.getUser().getUserImgUrl()
-                ),
-                review.getProduct().getId()
-            ))
-            .collect(Collectors.toList());
-    }
-
-    /**
-     * 상품을 기반으로 리뷰 조회
-     * @param productId 상품 id
-     * @return list 형식의 reviewDTO
-     */
-    public List<ReviewDTO> getReviewsByProduct(Long productId) {
+    public List<ReviewDTO> getReviews(Long productId) {
         List<Review> reviews = reviewRepository.findByProductId(productId);
 
         if (reviews.isEmpty()) {
@@ -83,17 +44,43 @@ public class ReviewService {
         }
 
         return reviews.stream()
-            .map(review -> new ReviewDTO(
-                review.getId(),
-                review.getRate(),
-                review.getContent(),
-                new UserDTO(
+            .map(review -> ReviewDTO.builder()
+                .id(review.getId())
+                .rate(review.getRate())
+                .content(review.getContent())
+                .user(new UserDTO(
                     review.getUser().getId(),
                     review.getUser().getUserName(),
                     review.getUser().getUserImgUrl()
-                ),
-                review.getProduct().getId()
-            ))
+                ))
+                .productId(review.getProduct().getId())
+                .build()
+            )
+            .collect(Collectors.toList());
+    }
+
+    /**
+     * 특정 유저의 리뷰 조회
+     *
+     * @param kakaoId 카카오 id
+     * @return 특정 유저에 대한 list 형식의 reviewDTO
+     *
+     * todo: kakaoId가 아닌 userId를 받아와서 작업
+     */
+    public List<ReviewDTO> getReviewsByUser(String kakaoId) {
+        Long userId = userRepository.findByKakaoId(kakaoId)
+            .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        List<Review> reviews = reviewRepository.findByUserId(userId);
+
+        return reviews.stream()
+            .map(review -> ReviewDTO.builder()
+                .id(review.getId())
+                .rate(review.getRate())
+                .content(review.getContent())
+                .productImgUrl(Optional.ofNullable(review.getProduct().getProductImageUrl()))
+                .build()
+            )
             .collect(Collectors.toList());
     }
 
@@ -103,7 +90,7 @@ public class ReviewService {
      * @return 리뷰 평균 평점
      */
     public Double getAverageRating(Long productId) {
-        List<ReviewDTO> reviews = getReviewsByProduct(productId);
+        List<ReviewDTO> reviews = getReviews(productId);
         return reviews.stream()
             .mapToDouble(ReviewDTO::rate)
             .average()
@@ -114,12 +101,13 @@ public class ReviewService {
      * 새 리뷰 생성
      *
      * @param reviewDTO 리뷰 DTO
-     * @param token     유저 토큰
+     * @param kakaoId   카카오 id
      *
-     * @todo 파싱된 정보에서 user에 대한 정보를 기반으로 userId와 하위 로직을 수정해야 함
+     * @todo: kakaoId가 아닌 userId를 받아와서 작업
      */
-    public void createReview(ReviewDTO reviewDTO, String token) {
-        Long userId = reviewDTO.user().id();
+    public void createReview(ReviewDTO reviewDTO, String kakaoId) {
+        Long userId = userRepository.findByKakaoId(kakaoId)
+            .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
 
         User user = userRepository.findById(userId)
             .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
@@ -144,10 +132,19 @@ public class ReviewService {
      *
      * @param id        리뷰 id
      * @param reviewDTO 리뷰 DTO
+     *
+     * @todo: kakaoId가 아닌 userId를 받아와서 작업
      */
-    public void updateReviews(Long id, ReviewDTO reviewDTO) {
+    public void updateReviews(Long id, ReviewDTO reviewDTO, String kakaoId) {
+        Long userId = userRepository.findByKakaoId(kakaoId)
+            .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
         Review existingReview = reviewRepository.findById(id)
             .orElseThrow(()-> new IllegalArgumentException("해당 상품의 리뷰가 존재하지 않습니다."));
+
+        if (!existingReview.getUser().getId().equals(userId)) {
+            throw new IllegalStateException("해당 리뷰를 수정할 권한이 없습니다.");
+        }
 
         Review updateReview = new Review(
             existingReview.getId(),
@@ -163,22 +160,23 @@ public class ReviewService {
     /**
      * 리뷰 삭제
      *
-     * @param id 리뷰 id
+     * @param id      리뷰 id
+     * @param kakaoId 카카오 id
+     *
+     * @todo kakaoId가 아닌 userId를 받아와서 작업
      */
-    public void deleteReviews(Long id) {
+    public void deleteReviews(Long id, String kakaoId) {
+        Long userId = userRepository.findByKakaoId(kakaoId)
+            .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
         Review existingReview = reviewRepository.findById(id)
-            .orElseThrow(() -> new IllegalArgumentException("ID: " + id + "에 대한 리뷰를 찾을 수 없습니다."));
+            .orElseThrow(() -> new IllegalArgumentException("해당 리뷰를 찾을 수 없습니다."));
+
+        if (!existingReview.getUser().getId().equals(userId)) {
+            throw new IllegalStateException("해당 리뷰를 삭제할 권한이 없습니다.");
+        }
 
         reviewRepository.delete(existingReview);
-    }
-
-    /**
-     * 상품 ID로 리뷰 삭제
-     * @param productId 상품 id
-     */
-    public void deleteReviewsByProductId(Long productId) {
-        List<Review> reviews = reviewRepository.findByProductId(productId);
-        reviewRepository.deleteAll(reviews);
     }
 
 }

--- a/src/test/java/jeje/work/aeatbe/EntityRepositoryTests.java
+++ b/src/test/java/jeje/work/aeatbe/EntityRepositoryTests.java
@@ -1,5 +1,5 @@
 package jeje.work.aeatbe;
-import jeje.work.aeatbe.dto.AllergyCategory.AllergyCategoryDTO;
+import jeje.work.aeatbe.dto.allergyCategory.AllergyCategoryDTO;
 import jeje.work.aeatbe.entity.*;
 import jeje.work.aeatbe.repository.*;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/jeje/work/aeatbe/WishListServiceTest.java
+++ b/src/test/java/jeje/work/aeatbe/WishListServiceTest.java
@@ -80,6 +80,7 @@ public class WishListServiceTest {
                 "ingredients",
                 1000L,
                 null,
+                null,
                 null
         );
 
@@ -96,7 +97,8 @@ public class WishListServiceTest {
                 "ingredients",
                 1000L,
                 null,
-                null
+                null,
+            null
         );
 
         wishlist = new Wishlist(1L, user, oldProduct);

--- a/src/test/java/jeje/work/aeatbe/mapper/allergyCategory/AllergyCategoryMapperTest.java
+++ b/src/test/java/jeje/work/aeatbe/mapper/allergyCategory/AllergyCategoryMapperTest.java
@@ -1,6 +1,6 @@
 package jeje.work.aeatbe.mapper.allergyCategory;
 
-import jeje.work.aeatbe.dto.AllergyCategory.AllergyCategoryDTO;
+import jeje.work.aeatbe.dto.allergyCategory.AllergyCategoryDTO;
 import jeje.work.aeatbe.entity.AllergyCategory;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/jeje/work/aeatbe/service/ProductServiceTest.java
+++ b/src/test/java/jeje/work/aeatbe/service/ProductServiceTest.java
@@ -1,6 +1,6 @@
 package jeje.work.aeatbe.service;
 
-import jeje.work.aeatbe.dto.AllergyCategory.AllergyCategoryDTO;
+import jeje.work.aeatbe.dto.allergyCategory.AllergyCategoryDTO;
 import jeje.work.aeatbe.dto.freeFromCategory.FreeFromCategoryDTO;
 import jeje.work.aeatbe.dto.product.ProductDTO;
 import jeje.work.aeatbe.dto.product.ProductResponseDTO;
@@ -154,7 +154,6 @@ class ProductServiceTest {
     void deleteProduct_Success() {
         // given
         when(productRepository.findById(product.getId())).thenReturn(Optional.of(product));
-        doNothing().when(reviewService).deleteReviewsByProductId(product.getId());
         doNothing().when(productRepository).delete(product);
 
         // when


### PR DESCRIPTION
- reviewService에서 이전에 추가한 빌더 패턴을 활용하게끔 수정하였습니다.
- 이전에는 review로 GET 요청 시, 마이페이지 여부를 searchByUser 필드로 구분하였으나, 가독성이 떨어지고 토큰이 불필요하게 남용된다고 판단됐습니다. 따라서 기존 '/api/reviews'를 전체 리뷰 조회와 마이페이지 조회('/api/reviews/my')로 분리하여, 마이페이지에서만 토큰 활용이 필수일 수 있게 수정하였습니다.
- 프론트와 상의 결과 마이페이지에서 리뷰 조회 시, 해당 상품의 이미지가 필요하다고 판단되었습니다. 따라서 해당 필드를 optional로 추가하여 선택적으로 포함할 수 있게끔 수정하였습니다.
- reviewService에 중복되는 메서드를 제거하고, 리뷰 삭제 시 productId가 아닌 reviewId를 활용하게끔 수정하였습니다.
- 위 항목을 위해 product에 review와 연관관계를 매핑하여, 상품 삭제 시 리뷰가 함께 삭제되게끔 수정했습니다.
- userEntity에 kakaoId 필드를 추가하였습니다. 해당 필드는 추후에 삭제 예정이나, 현재는 findBykakaoId 메서드에 대한 쿼리 생성이 필요하여  임시로 만들어 놓았습니다.
- 위 항목들에 따라 필요한 부분들의 testcode를 수정하였습니다. 부족한 test code는 상품 api를 작성하며 추가하도록 하겠습니다.

=> 현재는 jwt 토큰에서 파싱된 String 타입의 kakaoId를 사용하고 있으나, 추후에 이를 기반으로 userId를 반환하게 수정할 예정입니다. 수정이 완료되면 kakaoId를 사용하는 부분도 그에 맞게 수정 할 예정입니다. 해당 내용은 userId가 필요한 메서드에 @todo 로 적어놓았습니다.