### PR TITLE
refactor : api 호출 로직 수정 및 알러지 카테고리 재분류

### DIFF
--- a/src/main/java/jeje/work/aeatbe/controller/HaccpController.java
+++ b/src/main/java/jeje/work/aeatbe/controller/HaccpController.java
@@ -30,7 +30,7 @@
 ////        String apiUrl = haccpService.getProductApiUrl(); // 생성된 URL 가져오기
 ////        System.out.println("Redirecting to: " + apiUrl); // 리다이렉트할 URL 로그 출력
 //
-//        haccpService.getProductApi();
+//        haccpService.getAllProducts();
 ////        return new RedirectView(apiUrl); // 해당 URL로 리다이렉트
 //    }
 //}

--- a/src/main/java/jeje/work/aeatbe/dto/product/ProductDTO.java
+++ b/src/main/java/jeje/work/aeatbe/dto/product/ProductDTO.java
@@ -19,12 +19,12 @@ public record ProductDTO(
         @JsonProperty("imgurl2") String metaImageUrl, // 상품 상세 설명 이미지
         @JsonProperty("prdkind") String typeName, // 제품 종류(유형명)
         @JsonProperty("manufacture") String manufacturer, // 제조사
-        String seller, // 판매 링크(추후에 사용 될 예정)
+        String seller,                                         // todo: 판매 링크(추후에 사용 될 예정)
         @JsonProperty("capacity") String capacity, // 용량
         @JsonProperty("prdlstNm") String productName, // 상품명
         @JsonProperty("rawmtrl") String ingredients, // 원재료
         Long price,  // 가격(추후에 사용 될 예정)
-        @JsonProperty("barcode") String productBarcode, // 상품 바코드
+        @JsonProperty("barcode") String productBarcode, // 상품 바코드(현재 미사용중)
         String tag
 ) {
 }

--- a/src/main/java/jeje/work/aeatbe/entity/Product.java
+++ b/src/main/java/jeje/work/aeatbe/entity/Product.java
@@ -35,13 +35,13 @@ public class Product extends BaseEntity{
     @Column(name = "type_name", length = 200)
     private String typeName;
 
-    @Column(length = 50)
+    @Column(length = 200)
     private String manufacturer;
 
     @Column(length = 50)
     private String seller;
 
-    @Column(length = 20)
+    @Column(length = 100)
     private String capacity;
 
     @Column(name = "product_name", nullable = false, length = 50)

--- a/src/main/java/jeje/work/aeatbe/repository/ProductRepository.java
+++ b/src/main/java/jeje/work/aeatbe/repository/ProductRepository.java
@@ -12,9 +12,9 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface ProductRepository extends JpaRepository<Product, Long> {
     Page<Product> findByProductNameContaining(String q, Pageable pageable);
-
-    @Query("SELECT p FROM Product p JOIN p.productAllergies a WHERE a.allergy IN :allergies")
-    Page<Product> findByAllergy(List<String> allergies, Pageable pageable);
+    
+    @Query("SELECT p FROM Product p WHERE NOT EXISTS (SELECT a FROM p.productAllergies a WHERE a.allergy IN :allergies)")
+    Page<Product> findByAllergyNotIn(List<String> allergies, Pageable pageable);
 
     @Query("SELECT p FROM Product p JOIN p.productFreeFroms f WHERE f.freeFromCategory IN :freeFroms")
     Page<Product> findByFreeFrom(List<String> freeFroms, Pageable pageable);

--- a/src/main/java/jeje/work/aeatbe/service/AllergyCategoryService.java
+++ b/src/main/java/jeje/work/aeatbe/service/AllergyCategoryService.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.stream.Collectors;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * 알러지 카테고리 서비스 레이어
@@ -41,6 +42,7 @@ public class AllergyCategoryService {
      * @return 조회된 알러지 카테고리
      * @throws AllergyCategoryNotFoundException 조회된 알러지 카테고리가 없을 경우 예외 발생
      */
+    @Transactional
     public AllergyCategoryDTO getProductAllergyByType(String allergyType) {
         AllergyCategory allergyCategory = allergyCategoryRepository.findByAllergyType(allergyType)
                 .orElseThrow(() -> new AllergyCategoryNotFoundException("해당 알러지 카테고리가 존재하지 않습니다."));

--- a/src/main/java/jeje/work/aeatbe/service/HaccpParsingService.java
+++ b/src/main/java/jeje/work/aeatbe/service/HaccpParsingService.java
@@ -88,7 +88,6 @@ public class HaccpParsingService {
             throw new RuntimeException("JSON 파싱 중 에러 발생", e);
         }
 
-//        System.out.println("파싱된 상품 수: " + productDTOList.size());
         return productDTOList;
     }
 
@@ -114,8 +113,6 @@ public class HaccpParsingService {
                 if (allergyType.equals("없음")) continue;
 
                 AllergyCategoryDTO allergyCategoryDTO = allergyCategoryService.getProductAllergyByType(allergyType);
-
-//                System.out.println("이 부분이 null인가요?" + allergyCategoryDTO);
 
                 ProductAllergyDTO allergyDTO = ProductAllergyDTO.builder()
                     .allergyId(allergyCategoryDTO.id())
@@ -162,7 +159,7 @@ public class HaccpParsingService {
     /**
      * 파싱된 정보로 ProductDTO를 생성
      *
-     * @param item      JSON 아이템 객체
+     * @param item      상품 정보가 담긴 객체
      * @param allergies ProductAllergyDTO 리스트
      * @return ProductDTO
      */

--- a/src/main/java/jeje/work/aeatbe/service/HaccpParsingService.java
+++ b/src/main/java/jeje/work/aeatbe/service/HaccpParsingService.java
@@ -1,12 +1,21 @@
 package jeje.work.aeatbe.service;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
-import java.util.Random;
+import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Collectors;
 import jeje.work.aeatbe.dto.allergyCategory.AllergyCategoryDTO;
 import jeje.work.aeatbe.dto.product.ProductAllergyDTO;
 import jeje.work.aeatbe.dto.product.ProductDTO;
+import jeje.work.aeatbe.entity.AllergyCategory;
+import jeje.work.aeatbe.entity.Product;
+import jeje.work.aeatbe.entity.ProductAllergy;
 import jeje.work.aeatbe.mapper.product.ProductMapper;
+import jeje.work.aeatbe.repository.AllergyCategoryRepository;
+import jeje.work.aeatbe.repository.ProductAllergyRepository;
 import jeje.work.aeatbe.repository.ProductRepository;
 import lombok.RequiredArgsConstructor;
 import org.json.simple.JSONArray;
@@ -16,33 +25,47 @@ import org.json.simple.parser.ParseException;
 import org.springframework.stereotype.Service;
 
 /**
- * Haccp api 파싱 서비스
+ * Haccp API 파싱 서비스
  */
 @Service
 @RequiredArgsConstructor
 public class HaccpParsingService {
-    private final Random random = new Random();
-
+    private final ThreadLocalRandom random = ThreadLocalRandom.current();
     private final AllergyCategoryService allergyCategoryService;
     private final ProductMapper productMapper;
     private final ProductRepository productRepository;
+    private final ProductAllergyRepository productAllergyRepository;
+    private final AllergyCategoryRepository allergyCategoryRepository;
+    private final List<String> allergyList = Arrays.asList(
+        "난류", "우유", "메밀", "대두", "호두", "땅콩", "복숭아", "토마토", "닭고기", "돼지고기",
+        "쇠고기", "새우", "고등어", "홍합", "전복", "굴", "조개류", "게", "오징어", "아황산류", "잣", "콩류", "아몬드", "밀"
+    );
+
 
     /**
-     * Json parsing list.
+     * JSON 파싱 로직
      *
-     * @param response api 응답 문자열
-     * @return productDTO 리스트
+     * @param response API 응답 문자열
      */
-    public List<ProductDTO> jsonParsing(String response) {
+    public void jsonParsing(String response) {
+        if (response == null || response.isEmpty()) {
+            throw new IllegalArgumentException("API 응답이 비어 있습니다.");
+        }
+
         List<ProductDTO> productDTOList = parseJsonToProductDTOs(response);
 
+        System.out.println("상품 목록 저장 시작");
         for (ProductDTO productDTO : productDTOList) {
             saveProductDTO(productDTO);
         }
-
-        return productDTOList;
     }
 
+    /**
+     * JSON 응답 문자열을 파싱하여 ProductDTO로 변환
+     *
+     * @param response API 응답 JSON 문자열
+     * @return 파싱된 ProductDTO 목록
+     */
     private List<ProductDTO> parseJsonToProductDTOs(String response) {
         JSONParser jsonParser = new JSONParser();
         List<ProductDTO> productDTOList = new ArrayList<>();
@@ -59,41 +82,97 @@ public class HaccpParsingService {
                 List<ProductAllergyDTO> allergies = parseAllergyStringToDTO(allergyStr);
 
                 ProductDTO productDTO = buildJsonProductDTO(item, allergies);
-
                 productDTOList.add(productDTO);
             }
         } catch (ParseException e) {
             throw new RuntimeException("JSON 파싱 중 에러 발생", e);
         }
 
+//        System.out.println("파싱된 상품 수: " + productDTOList.size());
         return productDTOList;
     }
 
+    /**
+     * 호출된 api를 파싱하여 ProductAllergyDTO 목록을 생성
+     *
+     * @param allergyStr 알러지 정보 문자열
+     * @return 파싱된 ProductAllergyDTO 목록
+     */
     private List<ProductAllergyDTO> parseAllergyStringToDTO(String allergyStr) {
         List<ProductAllergyDTO> allergyDTOList = new ArrayList<>();
+
         if (allergyStr != null && !allergyStr.isEmpty()) {
-            String[] items = allergyStr.replaceAll("[\\[\\]']", "").split(",");
+            String[] items = allergyStr.replaceAll("[\\\\[\\\\]()]", " ").split(",");
+
             for (String item : items) {
                 String allergyType = item.trim();
+//                System.out.println("알러지 항목: " + allergyType);
 
-                if (allergyType.equals("없음")) {
-                    continue;
-                }
-                AllergyCategoryDTO allergyCategory = allergyCategoryService.getProductAllergyByType(allergyType);
+                allergyType = replaceWithCategory(allergyType);
+//                System.out.println("대체 후: " + allergyType);
+
+                if (allergyType.equals("없음")) continue;
+
+                AllergyCategoryDTO allergyCategoryDTO = allergyCategoryService.getProductAllergyByType(allergyType);
+
+//                System.out.println("이 부분이 null인가요?" + allergyCategoryDTO);
 
                 ProductAllergyDTO allergyDTO = ProductAllergyDTO.builder()
-                    .allergyId(allergyCategory.id())
+                    .allergyId(allergyCategoryDTO.id())
                     .build();
+
                 allergyDTOList.add(allergyDTO);
             }
         }
+
         return allergyDTOList;
     }
 
+    /**
+     * 알러지 타입을 적절한 카테고리로 대체
+     *
+     * @param allergyType 알러지 타입
+     * @return 대체된 알러지 카테고리
+     */
+    private String replaceWithCategory(String allergyType) {
+        Map<String, List<String>> categoryMap = new HashMap<>();
+        categoryMap.put("난류", Arrays.asList("알류", "계란", "메추리알", "난백", "난각칼슘", "난황분말"));
+        categoryMap.put("우유", Arrays.asList("탈지분유", "유청"));
+        categoryMap.put("대두", Arrays.asList("구아검", "두부", "백태", "적두", "레시틴"));
+        categoryMap.put("콩류", Arrays.asList("완두콩", "렌틸콩", "땅콩"));
+        categoryMap.put("조개류", Arrays.asList("바지락", "개량조개", "모시조개", "해조칼슘", "키조개", "소라", "가리비", "칼슘분말", "패각칼슘", "무수아황산", "위소라"));
+        categoryMap.put("닭고기", Arrays.asList("닭가슴살"));
+        categoryMap.put("쇠고기", Arrays.asList("소고기"));
+        categoryMap.put("돼지고기", Arrays.asList("돈지방", "돈창", "돈혈", "돈골"));
+        categoryMap.put("아황산류", Arrays.asList("아황산", "아황산나트륨", "산성아황산나트륨", "이산화황"));
+
+        for (String category : allergyList) {
+            if (allergyType.contains(category)) return category;
+        }
+
+        for (Map.Entry<String, List<String>> entry : categoryMap.entrySet()) {
+            for (String value : entry.getValue()) {
+                if (allergyType.contains(value)) return entry.getKey();
+            }
+        }
+
+        return "없음";
+    }
+
+    /**
+     * 파싱된 정보로 ProductDTO를 생성
+     *
+     * @param item      JSON 아이템 객체
+     * @param allergies ProductAllergyDTO 리스트
+     * @return ProductDTO
+     */
     private ProductDTO buildJsonProductDTO(JSONObject item, List<ProductAllergyDTO> allergies) {
+        String nutritionalInfo = (String) item.get("nutrient");
+        nutritionalInfo = nutritionalInfo == null ? "알수없음" : nutritionalInfo;
+
         return ProductDTO.builder()
             .allergy(allergies)
-            .nutritionalInfo((String) item.get("nutrient"))
+            .nutritionalInfo(nutritionalInfo)
             .productImageUrl((String) item.get("imgurl1"))
             .metaImageUrl((String) item.get("imgurl2"))
             .typeName((String) item.get("prdkind"))
@@ -107,8 +186,29 @@ public class HaccpParsingService {
             .build();
     }
 
+    /**
+     * ProductDTO를 데이터베이스에 저장
+     *
+     * @param productDTO ProductDTO 객체
+     */
     private void saveProductDTO(ProductDTO productDTO) {
-        productRepository.save(productMapper.toEntity(productDTO, true));
+        Product product = productRepository.save(productMapper.toEntity(productDTO, true));
+
+        List<Long> allergyIds = productDTO.allergy() != null ? productDTO.allergy().stream()
+            .map(ProductAllergyDTO::allergyId)
+            .collect(Collectors.toList()) : new ArrayList<>();
+
+        for (Long allergyId : allergyIds) {
+            AllergyCategory allergyCategory = allergyCategoryRepository.findById(allergyId)
+                .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 알러지 ID: " + allergyId));
+
+            ProductAllergy productAllergy = ProductAllergy.builder()
+                .product(product)
+                .allergy(allergyCategory)
+                .build();
+
+            productAllergyRepository.save(productAllergy);
+        }
     }
 
     private String randomTagGenerator() {

--- a/src/main/java/jeje/work/aeatbe/service/HaccpService.java
+++ b/src/main/java/jeje/work/aeatbe/service/HaccpService.java
@@ -1,6 +1,5 @@
 package jeje.work.aeatbe.service;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import org.springframework.beans.factory.annotation.Value;
@@ -9,33 +8,62 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.util.DefaultUriBuilderFactory;
 import org.springframework.web.util.UriComponentsBuilder;
-import reactor.core.publisher.Mono;
 
-/**
- * Haccp Service
- */
 @Service
 public class HaccpService {
     private final String serviceKey;
     private final String baseUrl;
     private final HaccpParsingService haccpParsingService;
-    private final ObjectMapper objectMapper;
-
 
     public HaccpService(@Value("${haccp.service_key}") String serviceKey,
         @Value("${haccp.base_url}") String baseUrl,
-        HaccpParsingService haccpParsingService,
-        ObjectMapper objectMapper) {
+        HaccpParsingService haccpParsingService) {
         this.serviceKey = URLEncoder.encode(serviceKey, StandardCharsets.UTF_8);
         this.baseUrl = baseUrl;
         this.haccpParsingService = haccpParsingService;
-        this.objectMapper = objectMapper;
     }
 
-    /**
-     * Gets product api.
-     */
-    public void getProductApi() {
+    public void getAllProducts() {
+//        int totalDataCount = 14881;
+        int totalDataCount = 4000;
+        int numOfRows = 100;
+
+        int totalPages = (int) Math.ceil((double) totalDataCount / numOfRows);
+
+        for (int pageNo = 1; pageNo <= totalPages; pageNo++) {
+            infinityChallengeCount(pageNo, 3);
+        }
+    }
+
+    private void infinityChallengeCount(int pageNo, int retry) {
+        while (retry > 0) {
+            if (fetchPageData(pageNo)) return;
+            retry--;
+            if (retry > 0) delayForRetry(pageNo, retry);
+        }
+        System.out.println("페이지 : " + pageNo + " 데이터 가져오기를 포기했어요");
+    }
+
+    private boolean fetchPageData(int pageNo) {
+        try {
+            String uriString = createUriString(pageNo);
+            String responseBody = callApi(uriString);
+            if (responseBody == null || responseBody.isEmpty()) {
+                System.out.println("API 응답이 비어 있습니다.");
+                return false;
+            }
+
+            System.out.println("응답 내용: " + responseBody); // 응답 내용 로그 출력
+
+            haccpParsingService.jsonParsing(responseBody);
+            return true;
+        } catch (Exception e) {
+            System.out.println("API 요청 중 오류 발생: " + e.getMessage());
+            return false;
+        }
+    }
+
+    private String callApi(String uriString) {
         DefaultUriBuilderFactory factory = new DefaultUriBuilderFactory();
         factory.setEncodingMode(DefaultUriBuilderFactory.EncodingMode.NONE);
 
@@ -44,31 +72,32 @@ public class HaccpService {
             .baseUrl(baseUrl)
             .build();
 
-        String uriString = UriComponentsBuilder.fromUriString(baseUrl)
-            .path("/getCertImgListServiceV3")
-            .queryParam("ServiceKey", serviceKey)
-            .queryParam("returnType", "json")
-//            .queryParam("pageNo", "1")       // 페이지 번호
-//            .queryParam("numOfRows", "100")  // 한 페이지 결과 수
-            .build(true)  // query parameter도 인코딩된 형태로 빌드
-            .toUriString();
-
-        System.out.println("Constructed URL: " + uriString);
-
-        Mono<String> response = webClient.get()
+        return webClient.get()
             .uri(uriString)
             .accept(MediaType.APPLICATION_JSON, MediaType.valueOf("text/json"))
             .retrieve()
             .bodyToMono(String.class)
-            .doOnError(error -> System.out.println("API 요청 중 오류 발생 : " + error.getMessage()))
-            .doOnNext(responseBody -> System.out.println("Response Body: " + responseBody))  // 응답 출력(확인용)
-            .doOnNext(haccpParsingService::jsonParsing)
-            .onErrorResume(error -> {
-                System.out.println("API 요청 중 오류 발생 : " + error.getMessage());
-                return Mono.empty();  // 에러 발생 시 빈 Mono를 반환
-            });
+            .doOnError(error -> System.out.println("API 요청 중 오류 발생1 : " + error.getMessage()))
+            .block();
+    }
 
-        response.subscribe();
+    private String createUriString(int pageNo) {
+        return UriComponentsBuilder.fromUriString(baseUrl)
+            .path("/getCertImgListServiceV3")
+            .queryParam("ServiceKey", serviceKey)
+            .queryParam("returnType", "json")
+            .queryParam("pageNo", pageNo)
+            .queryParam("numOfRows", "100")
+            .build(true)
+            .toUriString();
+    }
+
+    private void delayForRetry(int pageNo, int retries) {
+//        System.out.println("재시도 중 페이지 " + pageNo + ", 남은 시도 횟수: " + retries);
+        try {
+            Thread.sleep(1000);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
     }
 }
-

--- a/src/main/java/jeje/work/aeatbe/service/HaccpService.java
+++ b/src/main/java/jeje/work/aeatbe/service/HaccpService.java
@@ -9,11 +9,15 @@ import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.util.DefaultUriBuilderFactory;
 import org.springframework.web.util.UriComponentsBuilder;
 
+/**
+ * The type Haccp service.
+ */
 @Service
 public class HaccpService {
     private final String serviceKey;
     private final String baseUrl;
     private final HaccpParsingService haccpParsingService;
+
 
     public HaccpService(@Value("${haccp.service_key}") String serviceKey,
         @Value("${haccp.base_url}") String baseUrl,
@@ -23,6 +27,9 @@ public class HaccpService {
         this.haccpParsingService = haccpParsingService;
     }
 
+    /**
+     * haccp api내 상품 호출
+     */
     public void getAllProducts() {
 //        int totalDataCount = 14881;
         int totalDataCount = 4000;

--- a/src/main/java/jeje/work/aeatbe/service/ProductService.java
+++ b/src/main/java/jeje/work/aeatbe/service/ProductService.java
@@ -248,7 +248,7 @@ public class ProductService {
             return productRepository.findByProductNameContaining(q, pageable);
         }
         if (allergies != null && !allergies.isEmpty()) {
-            return productRepository.findByAllergy(allergies, pageable);
+            return productRepository.findByAllergyNotIn(allergies, pageable);
         }
         if (freeFroms != null && !freeFroms.isEmpty()) {
             return productRepository.findByFreeFrom(freeFroms, pageable);

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,5 +1,5 @@
 INSERT IGNORE INTO allergy_categories (allergy_type)
-VALUES ('알류'),
+VALUES ('난류'),
        ('우유'),
        ('메밀'),
        ('땅콩'),
@@ -18,8 +18,11 @@ VALUES ('알류'),
        ('돼지고기'),
        ('쇠고기'),
        ('아황산류'),
-       ('아몬드'),
-       ('TEST');
+       ('홍합'),
+       ('전복'),
+       ('굴'),
+       ('콩류'),
+       ('아몬드');
 
 INSERT IGNORE INTO free_from_categories (free_from_type)
 VALUES ('글루텐 프리'),


### PR DESCRIPTION
- 기존에 분류해둔 알러지 카테고리가, api를 통해 들어오는 알러지 기준들이 달라 일관된 24개의 카테고리로 재분류했습니다. 유사 항목은 공통 카테고리로 묶었고, 중요도가 높은 독립성적인 항목들은 개별 카테고리로 설정하였습니다.

- 기존 productService 로직 내 상품 알러지 필터링 방식이 수정되었습니다.
	- 기존 : 해당 알러지를 가진 상품들을 반환 
	- 수정 후 : 해당 알러지를 제외한 상품들을 반환

- 제조사 및 상품 용량이 기존 필드보다 짧아 api 호출 중 누락된 항목들이 다수 발견되었습니다. 이를 방지하기 위해 해당 필드들의 길이를 두 배로 증가하였습니다.

- 현재 api 요청 중 다수의 페이지를 반복적으로 가져오고 있습니다. 이때 AllergyCategoryService 내getProductAllergyByType에 대한 요청이 많은 상황에서 데이터의 일관성 유지를 위해 @Transactional을 추가하였습니다.

- 기존에 Product와 AllergyCategory를 다대다로 연결하고 있었던 로직을 product <- product_allergy -> allergyCategory 로 중간 테이블을 활용하여 해소하였습니다.

- weekly/10에 코드 리뷰를 반영하여 Random대신 TreadLocalRandom을 사용하도록 수정하였습니다.
   - https://github.com/kakao-tech-campus-2nd-step3/Team2_BE/pull/97#discussion_r1835629403

- api 호출 중 데이터 누락 및 에러 항목들을 최대한 줄이기위해 재시도 횟수를 설정을 위한 메서드를 생성하였습니다.