### PR TITLE
refactor: articleLikes관련 수정

### DIFF
--- a/src/main/java/jeje/work/aeatbe/config/WebConfig.java
+++ b/src/main/java/jeje/work/aeatbe/config/WebConfig.java
@@ -2,6 +2,7 @@ package jeje.work.aeatbe.config;
 
 import jeje.work.aeatbe.interceptor.JwtInterceptor;
 import jeje.work.aeatbe.resolver.LoginUserArgumentResolver;
+import jeje.work.aeatbe.service.TokenService;
 import jeje.work.aeatbe.service.UserService;
 import jeje.work.aeatbe.utility.JwtUtil;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +21,7 @@ public class WebConfig implements WebMvcConfigurer {
     private final UserService userService;
     private final JwtInterceptor jwtInterceptor;
     private final JwtUtil jwtUtil;
+    private final TokenService tokenService;
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
@@ -33,7 +35,7 @@ public class WebConfig implements WebMvcConfigurer {
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> argumentResolvers) {
-        argumentResolvers.add(new LoginUserArgumentResolver(jwtUtil, userService));
+        argumentResolvers.add(new LoginUserArgumentResolver(jwtUtil, userService, tokenService));
     }
 
     @Override

--- a/src/main/java/jeje/work/aeatbe/dto/review/ReviewDTO.java
+++ b/src/main/java/jeje/work/aeatbe/dto/review/ReviewDTO.java
@@ -1,6 +1,7 @@
 package jeje.work.aeatbe.dto.review;
 
 import jakarta.annotation.Nullable;
+import java.time.LocalDateTime;
 import lombok.Builder;
 
 @Builder
@@ -10,7 +11,7 @@ public record ReviewDTO(
         String content,
         Long userId,
         Long productId,
-
+        LocalDateTime date,
         @Nullable
         String productImgUrl) {
 }

--- a/src/main/java/jeje/work/aeatbe/dto/review/ReviewResponseDTO.java
+++ b/src/main/java/jeje/work/aeatbe/dto/review/ReviewResponseDTO.java
@@ -1,5 +1,6 @@
 package jeje.work.aeatbe.dto.review;
 
+import java.time.LocalDateTime;
 import jeje.work.aeatbe.dto.user.UserInfoResponseDTO;
 import lombok.Builder;
 
@@ -10,6 +11,8 @@ public record ReviewResponseDTO(
         String content,
         UserInfoResponseDTO user,
         Long productId,
-        String productImgUrl
+        String productImgUrl,
+        String productName,
+        LocalDateTime date
 ) {
 }

--- a/src/main/java/jeje/work/aeatbe/interceptor/JwtInterceptor.java
+++ b/src/main/java/jeje/work/aeatbe/interceptor/JwtInterceptor.java
@@ -24,6 +24,12 @@ public class JwtInterceptor implements HandlerInterceptor {
     public boolean preHandle(final HttpServletRequest request, final HttpServletResponse response, final Object handler)
             throws Exception {
         String header = request.getHeader(HttpHeaders.AUTHORIZATION);
+        String requestURI = request.getRequestURI();
+        if (requestURI.startsWith("/api/article/likes")) {
+            // 해당 경로에 대한 별도 로직 추가
+            return true;
+        }
+
 
         if (header == null || !header.startsWith("Bearer ")) {
             throw new TokenException("헤더에 올바른 인증 토큰이 필요합니다.(Bearer )");

--- a/src/main/java/jeje/work/aeatbe/mapper/Review/ReviewMapper.java
+++ b/src/main/java/jeje/work/aeatbe/mapper/Review/ReviewMapper.java
@@ -16,6 +16,7 @@ public class ReviewMapper {
                 .userId(review.getUser().getId())
                 .productId(review.getProduct().getId())
                 .productImgUrl(review.getProduct().getProductImageUrl())
+                .date(review.getUpdatedAt())
                 .build();
     }
 

--- a/src/main/java/jeje/work/aeatbe/mapper/Review/ReviewResponseMapper.java
+++ b/src/main/java/jeje/work/aeatbe/mapper/Review/ReviewResponseMapper.java
@@ -16,6 +16,7 @@ public class ReviewResponseMapper {
                 .user(userInfoResponseDTO)
                 .productId(reviewDTO.productId())
                 .productImgUrl(productDto.productImageUrl())
+                .productName(productDto.productName())
                 .date(reviewDTO.date())
                 .build();
     }

--- a/src/main/java/jeje/work/aeatbe/mapper/Review/ReviewResponseMapper.java
+++ b/src/main/java/jeje/work/aeatbe/mapper/Review/ReviewResponseMapper.java
@@ -1,5 +1,6 @@
 package jeje.work.aeatbe.mapper.Review;
 
+import jeje.work.aeatbe.dto.product.ProductDTO;
 import jeje.work.aeatbe.dto.review.ReviewDTO;
 import jeje.work.aeatbe.dto.review.ReviewResponseDTO;
 import jeje.work.aeatbe.dto.user.UserInfoResponseDTO;
@@ -7,14 +8,15 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class ReviewResponseMapper {
-    public ReviewResponseDTO toDTO(ReviewDTO reviewDTO, UserInfoResponseDTO userInfoResponseDTO) {
+    public ReviewResponseDTO toDTO(ReviewDTO reviewDTO, UserInfoResponseDTO userInfoResponseDTO, ProductDTO productDto) {
         return ReviewResponseDTO.builder()
                 .id(reviewDTO.id())
                 .rate(reviewDTO.rate())
                 .content(reviewDTO.content())
                 .user(userInfoResponseDTO)
                 .productId(reviewDTO.productId())
-                .productImgUrl(reviewDTO.productImgUrl())
+                .productImgUrl(productDto.productImageUrl())
+                .date(reviewDTO.date())
                 .build();
     }
 }

--- a/src/main/java/jeje/work/aeatbe/resolver/LoginUserArgumentResolver.java
+++ b/src/main/java/jeje/work/aeatbe/resolver/LoginUserArgumentResolver.java
@@ -4,6 +4,8 @@ import jakarta.servlet.http.HttpServletRequest;
 import jeje.work.aeatbe.annotation.LoginUser;
 import jeje.work.aeatbe.dto.user.LoginUserInfo;
 import jeje.work.aeatbe.exception.TokenException;
+import jeje.work.aeatbe.exception.TokenExpException;
+import jeje.work.aeatbe.service.TokenService;
 import jeje.work.aeatbe.service.UserService;
 import jeje.work.aeatbe.utility.JwtUtil;
 import lombok.RequiredArgsConstructor;
@@ -20,7 +22,7 @@ public class LoginUserArgumentResolver implements HandlerMethodArgumentResolver 
 
     private final JwtUtil jwtUtil;
     private final UserService userService;
-
+    private final TokenService tokenService;
 
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
@@ -31,6 +33,36 @@ public class LoginUserArgumentResolver implements HandlerMethodArgumentResolver 
     public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
                                   NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
         HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
+        String requestURI = request.getRequestURI();
+
+        if (requestURI.startsWith("/api/article/likes")) {
+            String token = request.getHeader("Authorization");
+
+            if (token != null && token.startsWith("Bearer ")) {
+                token = token.substring(7);
+
+                if (tokenService.isInBlackList(token)) {
+                    throw new TokenException("이미로그아웃 된 사용자의 토큰입니다. 다시 로그인 해주세요");
+                }
+
+                if (jwtUtil.validTokenExpiration(token, true)) {
+                    throw new TokenExpException("만료된 토큰입니다.");
+                }
+
+
+                if (!userService.validateToken(token)) {
+                    throw new TokenException("올바르지 않은 토큰입니다.");
+                }
+
+                LoginUserInfo loginUserInfo = jwtUtil.getLoginUserInfo(token);
+                return loginUserInfo;
+            }
+
+            return new LoginUserInfo(-1L,"123");
+        }
+
+
+
         String token = request.getHeader("Authorization");
         if (token != null && token.startsWith("Bearer ")) {
             token = token.substring(7);

--- a/src/main/java/jeje/work/aeatbe/service/ReviewService.java
+++ b/src/main/java/jeje/work/aeatbe/service/ReviewService.java
@@ -89,7 +89,8 @@ public class ReviewService {
      */
     public ReviewResponseDTO getReviewResponseDTO(ReviewDTO review) {
         var userDTO = userService.getUserInfo(review.userId());
-        return reviewResponseMapper.toDTO(review, userDTO);
+        var productDTO = productService.getProductDTO(review.productId());
+        return reviewResponseMapper.toDTO(review, userDTO, productDTO);
     }
 
     /**


### PR DESCRIPTION
getArticleLikes시 로그인이 되어있지 않을경우 인터셉터에서 exception이 발생하여 articleLikes의 경로로 요청이 들어올때만 토큰이 있을 시  argumentReslover에서 토큰검증을 하고 유저id를 -1로 주입하는 로직으로 변경하였습니다.